### PR TITLE
fix gateway error and write signature file on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@
 An actively maintained & developed fork of [gulp-tinypng-compress](https://github.com/stnvh/gulp-tinypng-compress).
 
 *Main differences from gulp-tinypng-compress:*
-- Added new option (keepOriginal) to override the original image instead of creating a new compressed file in the output path
 - Added new option (keepMetadata) to preserve metadata. Currently only copyright and creation date is supported.
-- Updated minimatch plugin to current version to avoid deprecated warnings
+- Added new option (keepOriginal) to override the original image instead of creating a new compressed file in the output path.
+- Updated minimatch plugin to current version to avoid deprecated warnings.
+- Fixed Problem with Bad Gateway errors receiving from the api. On error on one file the gulp process is still running and
+compressing the next images.
+- On error the signature file is still being written for all successfully compressed files.
 
 ## Install
 *Requires node `0.10.x` or above*
@@ -32,10 +35,12 @@ npm test
 
 ```js
 var gulp = require('gulp');
+var plumber = require('gulp-plumber');
 var tinypng = require('gulp-tinypng-extended');
 
 gulp.task('tinypng', function () {
 	gulp.src('images/src/**/*.{png,jpg,jpeg}')
+		.pipe(plumber())
 		.pipe(tinypng({
 			key: 'API_KEY',
 			sigFile: 'images/.tinypng-sigs',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,11 +2,13 @@ process.env.NODE_ENV = 'normal';
 
 var gulp = require('gulp'),
     tinypng = require('./index'),
+    plumber = require('gulp-plumber'),
     cwd = __dirname,
     sigs = process.env.TINYPNG_SIGS ? true : false;
 
 gulp.task('tinypng', function() {
     gulp.src(cwd + '/test/assets/image.png')
+        .pipe(plumber())
         .pipe(tinypng({
             key: process.env.TINYPNG_KEY || 'KHOsJMrP6w-X3FVuyXdevV-vCnDDbqo9',
             log: true,

--- a/package.json
+++ b/package.json
@@ -44,15 +44,17 @@
   },
   "license": "MIT",
   "dependencies": {
+    "gulp-plumber": "^1.1.0",
     "gulp-util": "~3.0.0",
+    "minimatch": "^3.0.0",
     "request": "~2.55.0",
     "through2": "^2.0.0",
-    "through2-concurrent": "^1.1.0",
-    "minimatch": "^3.0.0"
+    "through2-concurrent": "^1.1.0"
   },
   "devDependencies": {
     "chai": "^2.0.0",
     "gulp": "^3.0.0",
-    "mocha": "^2.0.0"
+    "mocha": "^2.0.0",
+    "nock": "^9.0.4"
   }
 }

--- a/test/init.js
+++ b/test/init.js
@@ -5,6 +5,7 @@ var fs = require('fs'),
 	crypto = require('crypto'),
 	expect = require('chai').expect,
     gutil = require('gulp-util'),
+    nock = require('nock'),
 
 	dry = process.env.PNG_DRY ? true : false,
 
@@ -84,6 +85,22 @@ describe('tinypng', function() {
 
 					done();
 				});
+			});
+
+			it('uploads and returns bad gateway error', function(done) {
+				this.timeout(20010);
+
+				var gateway = nock('https://api.tinify.com')
+								.post('/shrink')
+								.reply(502, '<html><head><title>502 Bad Gateway</title></head><body><h1>502 Bad Gateway</h1></body></html>');
+
+				inst.request(image).upload(function(err, data) {
+					expect(err).to.be.instanceof(Error);
+					expect(err.message).to.equal('Error: Statuscode 502 returned');
+					nock.cleanAll();
+					done();
+				});
+
 			});
 		});
 


### PR DESCRIPTION
Changed error handling and added gulp-plumber to keep gulp watch still processing files when error occurs. Also keeps writing the signature file for all successfully compressed images and just skip all with errors.

fixes #7 