### PR TITLE
skip broken and empty images

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@
 
 An actively maintained & developed fork of [gulp-tinypng-compress](https://github.com/stnvh/gulp-tinypng-compress).
 
-*Main differences from gulp-tinypng-compress:*
+## Main differences from gulp-tinypng-compress
 - Added new option (keepMetadata) to preserve metadata. Currently only copyright and creation date is supported.
 - Added new option (keepOriginal) to override the original image instead of creating a new compressed file in the output path.
 - Updated minimatch plugin to current version to avoid deprecated warnings.
 - Fixed Problem with Bad Gateway errors receiving from the api. On error on one file the gulp process is still running and
 compressing the next images.
 - On error the signature file is still being written for all successfully compressed files.
+- Added check for empty or broken images to be skipped and not send
 
 ## Install
 *Requires node `0.10.x` or above*

--- a/index.js
+++ b/index.js
@@ -168,6 +168,12 @@ function TinyPNG(opt, obj) {
             upload: function(cb) {
                 var file = this.file;
 
+                //do not process empty files
+                if(file.contents <= 0) {
+                    err = new Error('Error: Empty or broken images could not be send ' + file.relative);
+                    return cb(err);
+                }
+
                 request.post({
                     url: 'https://api.tinify.com/shrink',
                     headers: {

--- a/test/init.js
+++ b/test/init.js
@@ -13,8 +13,8 @@ var fs = require('fs'),
 
 var key = 'KHOsJMrP6w-X3FVuyXdevV-vCnDDbqo9',
 	cwd = __dirname,
-	TestFile = function(small) {
-		var file = cwd + '/assets/image' + (small ? '_small' : '') + '.png';
+	TestFile = function(type) {
+		var file = cwd + '/assets/image' + (type ? '_' + type : '') + '.png';
 
 		return new gutil.File({
 			path: 'image.png',
@@ -66,7 +66,8 @@ describe('tinypng', function() {
 	describe('#request', function() {
 		var struct = ['file', 'upload', 'download', 'handler', 'get'],
 			inst = new TinyPNG(key),
-			image = new TestFile();
+			image = new TestFile(),
+			empty_image = new TestFile('empty');
 
 		it('returns correct object', function() {
 			expect(inst.request()).to.have.all.keys(struct);
@@ -98,6 +99,17 @@ describe('tinypng', function() {
 					expect(err).to.be.instanceof(Error);
 					expect(err.message).to.equal('Error: Statuscode 502 returned');
 					nock.cleanAll();
+					done();
+				});
+
+			});
+
+			it('upload empty file should throw error, skip and not break the plugin', function(done) {
+				this.timeout(2000);
+
+				inst.request(empty_image).upload(function(err, data) {
+					expect(err).to.be.instanceof(Error);
+					expect(err.message).to.equal('Error: Empty or broken images could not be send image.png');
 					done();
 				});
 


### PR DESCRIPTION
Skips on empty or broken images and throws an error in the console but keeps plugin running. Fixes #9 