### PR TITLE
add retry attempts for failed upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 node_modules/
 test/assets/tmp

--- a/README.md
+++ b/README.md
@@ -149,13 +149,13 @@ Same as `options.force` except ignores files if the glob is matched
 
 `--ignore` flag on the command line
 
-#### options.retry_attempts
+#### options.retryAttempts
 Type: `Integer`
 Default: `10`
 
 How many times to reattempt the upload if an error is encountered.
 
-#### options.retry_delay
+#### options.retryDelay
 Type: `Integer`
 Default: `10000`
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,18 @@ Same as `options.force` except ignores files if the glob is matched
 
 `--ignore` flag on the command line
 
+#### options.retry_attempts
+Type: `Integer`
+Default: `10`
+
+How many times to reattempt the upload if an error is encountered.
+
+#### options.retry_delay
+Type: `Integer`
+Default: `10000`
+
+How many milliseconds to delay before reattempting a failed upload.
+
 ### Deprecated/non-functional options
 
 **options.checkSigs** - Removed in favor of `options.sigFile`

--- a/index.js
+++ b/index.js
@@ -203,8 +203,7 @@ function TinyPNG(opt, obj) {
                             url: false,
                             count: (res && 'headers' in res && res.headers['compression-count']) || 0
                         };
-
-                    if(res.attempts > 1){
+                    if(res && res.attempts > 1){
                         self.stats.retries += res.attempts - 1;
                         self.stats.retried.push({
                             file: file.relative,

--- a/index.js
+++ b/index.js
@@ -35,6 +35,8 @@ function TinyPNG(opt, obj) {
             parallelMax: 5,
             keepOriginal: true,
             keepMetadata: false,
+            retry_attempts: 10,
+            retry_delay: 10000
         }
     };
 
@@ -192,8 +194,8 @@ function TinyPNG(opt, obj) {
                     },
                     strictSSL: false,
                     body: file.contents,
-                    maxAttempts: 10,   // (default) try 10 times
-                    retryDelay: 10000,  // (default) wait for 10s before trying again
+                    maxAttempts: self.conf.retry_attempts,
+                    retryDelay: self.conf.retry_delay,
                     retryStrategy: request.RetryStrategies.HTTPOrNetworkError // (default) retry on 5xx or network errors
                 }, function (err, res, body) {
                     var data,

--- a/index.js
+++ b/index.js
@@ -51,16 +51,16 @@ function TinyPNG(opt, obj) {
         retried: []
     };
 
-    this.init = function (opt) {
-        if (typeof opt !== 'object') opt = {key: opt};
+    this.init = function(opt) {
+        if(typeof opt !== 'object') opt = {key: opt};
 
         opt = util._extend(this.conf.options, opt);
 
-        if (!opt.key) throw new PluginError(PLUGIN_NAME, 'Missing API key!');
+        if(!opt.key) throw new PluginError(PLUGIN_NAME, 'Missing API key!');
 
-        if (!opt.force) opt.force = gutil.env.force || false; // force match glob
-        if (!opt.ignore) opt.ignore = gutil.env.ignore || false; // ignore match glob
-        if (opt.summarise) opt.summarize = true; // chin chin, old chap!
+        if(!opt.force) opt.force = gutil.env.force || false; // force match glob
+        if(!opt.ignore) opt.ignore = gutil.env.ignore || false; // ignore match glob
+        if(opt.summarise) opt.summarize = true; // chin chin, old chap!
 
         this.conf.options = opt; // export opts
 
@@ -70,31 +70,31 @@ function TinyPNG(opt, obj) {
         return this;
     };
 
-    this.stream = function () {
+    this.stream = function() {
         var self = this,
             opt = this.conf.options;
 
-        return (opt.parallel ? throughParallel : through).obj({maxConcurrency: opt.parallelMax}, function (file, enc, cb) {
-            if (self.utils.glob(file, opt.ignore)) return cb();
+        return (opt.parallel ? throughParallel : through).obj({maxConcurrency: opt.parallelMax}, function(file, enc, cb) {
+            if(self.utils.glob(file, opt.ignore)) return cb();
 
-            if (file.isNull()) {
+            if(file.isNull()) {
                 return cb();
             }
 
-            if (file.isStream()) {
+            if(file.isStream()) {
                 this.emit('error', new PluginError(PLUGIN_NAME, 'Streams not supported'));
                 return cb();
             }
 
-            if (file.isBuffer()) {
+            if(file.isBuffer()) {
                 var hash = null;
 
-                if (opt.sigFile && !self.utils.glob(file, opt.force)) {
+                if(opt.sigFile && !self.utils.glob(file, opt.force)) {
                     var result = self.hash.compare(file);
 
                     hash = result.hash;
 
-                    if (result.match) {
+                    if(result.match) {
                         self.utils.log('[skipping] ' + chalk.green('✔ ') + file.relative);
                         self.stats.skipped++;
 
@@ -102,8 +102,8 @@ function TinyPNG(opt, obj) {
                     }
                 }
 
-                self.request(file).get(function (err, tinyFile) {
-                    if (err) {
+                self.request(file).get(function(err, tinyFile) {
+                    if(err) {
                         this.emit('error', new PluginError(PLUGIN_NAME, err));
                         return cb();
                     }
@@ -114,20 +114,20 @@ function TinyPNG(opt, obj) {
                     self.stats.total.in += file.contents.toString().length;
                     self.stats.total.out += tinyFile.contents.toString().length;
 
-                    if (opt.sigFile) {
+                    if(opt.sigFile) {
                         var curr = {
                             file: file,
                             hash: hash
                         };
 
-                        if (opt.sameDest) {
+                        if(opt.sameDest) {
                             curr.file = tinyFile;
                             curr.hash = self.hash.calc(tinyFile);
                         }
 
                         self.hash.update(curr.file, curr.hash);
                     }
-                    if (opt.keepOriginal === false) {
+                    if(opt.keepOriginal === false) {
                         fs.writeFile(file.path, tinyFile.contents);
                     } else {
                         this.push(tinyFile);
@@ -137,17 +137,17 @@ function TinyPNG(opt, obj) {
                 }.bind(this)); // maintain stream context
             }
         })
-            .on('error', function (err) {
+            .on('error', function(err) {
                 console.log(err.message);
                 self.stats.skipped++;
                 self.utils.log(err.message);
             })
-            .on('end', function () {
-                if (opt.sigFile) {
+            .on('end', function() {
+                if(opt.sigFile) {
                     // write sigs after complete or but also when error occured in order to keep track of already compressed files
                     self.hash.write();
                 }
-                if (opt.summarize) {
+                if(opt.summarize) {
                     var stats = self.stats,
                         info = util.format('Skipped: %s image%s, Retries: %s, Compressed: %s image%s, Savings: %s (ratio: %s)',
                             stats.skipped,
@@ -161,9 +161,9 @@ function TinyPNG(opt, obj) {
 
                     self.utils.log(info, true);
 
-                    if (stats.retries > 0) {
+                    if(stats.retries > 0) {
                         self.utils.log('Retry Attempts:', true);
-                        stats.retried.forEach(function (item) {
+                        stats.retried.forEach(function(item) {
                             self.utils.log(item.file + ': ' + item.attempts + ' attempts', true);
                         });
                     }
@@ -171,17 +171,17 @@ function TinyPNG(opt, obj) {
             });
     };
 
-    this.request = function (file, cb) {
+    this.request = function(file, cb) {
         var self = this;
 
         return {
             file: file,
 
-            upload: function (cb) {
+            upload: function(cb) {
                 var file = this.file;
 
                 //do not process empty files
-                if (file.contents <= 0) {
+                if(file.contents <= 0) {
                     err = new Error('Error: Empty or broken images could not be send ' + file.relative);
                     return cb(err);
                 }
@@ -197,35 +197,35 @@ function TinyPNG(opt, obj) {
                     maxAttempts: self.conf.retryAttempts,
                     retryDelay: self.conf.retryDelay,
                     retryStrategy: request.RetryStrategies.HTTPOrNetworkError // (default) retry on 5xx or network errors
-                }, function (err, res, body) {
+                }, function(err, res, body) {
                     var data,
                         info = {
                             url: false,
                             count: (res && 'headers' in res && res.headers['compression-count']) || 0
                         };
 
-                    if (res.attempts > 1) {
-                        self.stats.retries += res.attempts-1;
+                    if(res.attempts > 1) {
+                        self.stats.retries += res.attempts - 1;
                         self.stats.retried.push({
                             file: file.relative,
                             attempts: res.attempts
                         });
                     }
 
-                    if (err) {
+                    if(err) {
                         err = new Error('Upload failed for ' + file.relative + ' with error: ' + err.message);
-                    } else if (body) {
-                        if (res.statusCode == 200 || res.statusCode == 201) {
+                    } else if(body) {
+                        if(res.statusCode == 200 || res.statusCode == 201) {
                             try {
                                 data = JSON.parse(body);
-                            } catch (e) {
+                            } catch(e) {
                                 err = new Error('Upload response JSON parse failed, invalid data returned from API. Failed with message: ' + e.message);
                             }
 
-                            if (!err) {
-                                if (data.error) {
+                            if(!err) {
+                                if(data.error) {
                                     err = this.handler(data, res.statusCode);
-                                } else if (data.output.url) {
+                                } else if(data.output.url) {
                                     info.url = self.conf.options.keepMetadata ? res.headers.location : data.output.url;
                                 } else {
                                     err = new Error('Invalid TinyPNG response object returned for ' + file.relative);
@@ -242,24 +242,24 @@ function TinyPNG(opt, obj) {
                 }.bind(this));
             },
 
-            download: function (url, cb) {
+            download: function(url, cb) {
                 var options = {
                     url: url,
                     encoding: null
                 };
 
-                if (self.conf.options.keepMetadata) {
+                if(self.conf.options.keepMetadata) {
                     options.json = {preserve: ["copyright", "creation"]};
                     options.headers = {
                         'Authorization': 'Basic ' + self.conf.token
                     };
                 }
-                request.get(options, function (err, res, body) {
+                request.get(options, function(err, res, body) {
                     err = err ? new Error('Download failed for ' + url + ' with error: ' + err.message) : false;
                     var buffer = false;
                     try {
                         buffer = new Buffer(body);
-                    } catch (err) {
+                    } catch(err) {
                         return cb(new Error('Empty Body for Download with error: ' + err.message));
                     }
 
@@ -267,19 +267,19 @@ function TinyPNG(opt, obj) {
                 });
             },
 
-            handler: function (data, status) {
+            handler: function(data, status) {
                 return new Error((data.error || 'Unknown') + ' (' + status + '): ' + (data.message || 'No message returned') + ' for ' + file.relative);
             },
 
-            get: function (cb) {
+            get: function(cb) {
                 var self = this,
                     file = this.file;
 
-                self.upload(function (err, data) {
-                    if (err) return cb(err, file);
+                self.upload(function(err, data) {
+                    if(err) return cb(err, file);
 
-                    self.download(data.url, function (err, data) {
-                        if (err) return cb(err, file);
+                    self.download(data.url, function(err, data) {
+                        if(err) return cb(err, file);
 
                         var tinyFile = file.clone();
                         tinyFile.contents = data;
@@ -293,25 +293,25 @@ function TinyPNG(opt, obj) {
         };
     };
 
-    this.hasher = function (sigFile) {
+    this.hasher = function(sigFile) {
         return {
             sigFile: sigFile || false,
             sigs: {},
 
-            calc: function (file, cb) {
+            calc: function(file, cb) {
                 var md5 = crypto.createHash('md5').update(file.contents).digest('hex');
 
                 cb && cb(md5);
 
                 return cb ? this : md5;
             },
-            update: function (file, hash) {
+            update: function(file, hash) {
                 this.changed = true;
                 this.sigs[file.path.replace(file.cwd, '')] = hash;
 
                 return this;
             },
-            compare: function (file, cb) {
+            compare: function(file, cb) {
 
                 var md5 = this.calc(file),
                     filepath = file.path.replace(file.cwd, ''),
@@ -321,27 +321,27 @@ function TinyPNG(opt, obj) {
 
                 return cb ? this : {match: result, hash: md5};
             },
-            populate: function () {
+            populate: function() {
                 var data = false;
 
-                if (this.sigFile) {
+                if(this.sigFile) {
                     try {
                         data = fs.readFileSync(this.sigFile, 'utf-8');
-                        if (data) data = JSON.parse(data);
-                    } catch (err) {
+                        if(data) data = JSON.parse(data);
+                    } catch(err) {
                         // meh
                     }
 
-                    if (data) this.sigs = data;
+                    if(data) this.sigs = data;
                 }
 
                 return this;
             },
-            write: function () {
-                if (this.changed) {
+            write: function() {
+                if(this.changed) {
                     try {
                         fs.writeFileSync(this.sigFile, JSON.stringify(this.sigs));
-                    } catch (err) {
+                    } catch(err) {
                         // meh
                     }
                 }
@@ -352,32 +352,32 @@ function TinyPNG(opt, obj) {
     };
 
     this.utils = {
-        log: function (message, force) {
-            if (self.conf.options.log || force) gutil.log(PLUGIN_NAME, message);
+        log: function(message, force) {
+            if(self.conf.options.log || force) gutil.log(PLUGIN_NAME, message);
 
             return this;
         },
 
-        glob: function (file, glob, opt) {
+        glob: function(file, glob, opt) {
             opt = opt || {};
             var result = false;
 
-            if (typeof glob === 'boolean') return glob;
+            if(typeof glob === 'boolean') return glob;
 
             try {
                 result = minimatch(file.path, glob, opt);
-            } catch (err) {
+            } catch(err) {
             }
 
-            if (!result && !opt.matchBase) {
+            if(!result && !opt.matchBase) {
                 opt.matchBase = true;
                 return this.glob(file, glob, opt);
             }
             return result;
         },
 
-        prettySize: function (bytes) {
-            if (bytes === 0) return '0.00 B';
+        prettySize: function(bytes) {
+            if(bytes === 0) return '0.00 B';
 
             var pos = Math.floor(Math.log(bytes) / Math.log(1024));
             return (bytes / Math.pow(1024, pos)).toFixed(2) + ' ' + ' KMGTP'.charAt(pos) + 'B';

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var PLUGIN_NAME = 'gulp-tinypng-extended',
  * TinyPNG class
  * @todo Move into own library
  */
-function TinyPNG(opt, obj){
+function TinyPNG(opt, obj) {
 
     var self = this;
 
@@ -51,8 +51,8 @@ function TinyPNG(opt, obj){
         retried: []
     };
 
-    this.init = function(opt){
-        if(typeof opt !== 'object') opt = {key: opt};
+    this.init = function(opt) {
+        if(typeof opt !== 'object') opt = { key: opt };
 
         opt = util._extend(this.conf.options, opt);
 
@@ -70,11 +70,11 @@ function TinyPNG(opt, obj){
         return this;
     };
 
-    this.stream = function(){
+    this.stream = function() {
         var self = this,
             opt = this.conf.options;
 
-        return (opt.parallel ? throughParallel : through).obj({maxConcurrency: opt.parallelMax}, function(file, enc, cb){
+        return (opt.parallel ? throughParallel : through).obj({maxConcurrency: opt.parallelMax}, function(file, enc, cb) {
             if(self.utils.glob(file, opt.ignore)) return cb();
 
             if(file.isNull()){
@@ -102,7 +102,7 @@ function TinyPNG(opt, obj){
                     }
                 }
 
-                self.request(file).get(function(err, tinyFile){
+                self.request(file).get(function(err, tinyFile) {
                     if(err){
                         this.emit('error', new PluginError(PLUGIN_NAME, err));
                         return cb();
@@ -137,12 +137,12 @@ function TinyPNG(opt, obj){
                 }.bind(this)); // maintain stream context
             }
         })
-            .on('error', function(err){
+            .on('error', function(err) {
                 console.log(err.message);
                 self.stats.skipped++;
                 self.utils.log(err.message);
             })
-            .on('end', function(){
+            .on('end', function() {
                 if(opt.sigFile){
                     // write sigs after complete or but also when error occured in order to keep track of already compressed files
                     self.hash.write();
@@ -163,7 +163,7 @@ function TinyPNG(opt, obj){
 
                     if(stats.retries > 0){
                         self.utils.log('Retry Attempts:', true);
-                        stats.retried.forEach(function(item){
+                        stats.retried.forEach(function(item) {
                             self.utils.log(item.file + ': ' + item.attempts + ' attempts', true);
                         });
                     }
@@ -171,13 +171,13 @@ function TinyPNG(opt, obj){
             });
     };
 
-    this.request = function(file, cb){
+    this.request = function(file, cb) {
         var self = this;
 
         return {
             file: file,
 
-            upload: function(cb){
+            upload: function(cb) {
                 var file = this.file;
 
                 //do not process empty files
@@ -197,7 +197,7 @@ function TinyPNG(opt, obj){
                     maxAttempts: self.conf.retryAttempts,
                     retryDelay: self.conf.retryDelay,
                     retryStrategy: request.RetryStrategies.HTTPOrNetworkError // (default) retry on 5xx or network errors
-                }, function(err, res, body){
+                }, function(err, res, body) {
                     var data,
                         info = {
                             url: false,
@@ -242,7 +242,7 @@ function TinyPNG(opt, obj){
                 }.bind(this));
             },
 
-            download: function(url, cb){
+            download: function(url, cb) {
                 var options = {
                     url: url,
                     encoding: null
@@ -254,7 +254,7 @@ function TinyPNG(opt, obj){
                         'Authorization': 'Basic ' + self.conf.token
                     };
                 }
-                request.get(options, function(err, res, body){
+                request.get(options, function(err, res, body) {
                     err = err ? new Error('Download failed for ' + url + ' with error: ' + err.message) : false;
                     var buffer = false;
                     try{
@@ -267,18 +267,18 @@ function TinyPNG(opt, obj){
                 });
             },
 
-            handler: function(data, status){
+            handler: function(data, status) {
                 return new Error((data.error || 'Unknown') + ' (' + status + '): ' + (data.message || 'No message returned') + ' for ' + file.relative);
             },
 
-            get: function(cb){
+            get: function(cb) {
                 var self = this,
                     file = this.file;
 
-                self.upload(function(err, data){
+                self.upload(function(err, data) {
                     if(err) return cb(err, file);
 
-                    self.download(data.url, function(err, data){
+                    self.download(data.url, function(err, data) {
                         if(err) return cb(err, file);
 
                         var tinyFile = file.clone();
@@ -293,25 +293,25 @@ function TinyPNG(opt, obj){
         };
     };
 
-    this.hasher = function(sigFile){
+    this.hasher = function(sigFile) {
         return {
             sigFile: sigFile || false,
             sigs: {},
 
-            calc: function(file, cb){
+            calc: function(file, cb) {
                 var md5 = crypto.createHash('md5').update(file.contents).digest('hex');
 
                 cb && cb(md5);
 
                 return cb ? this : md5;
             },
-            update: function(file, hash){
+            update: function(file, hash) {
                 this.changed = true;
                 this.sigs[file.path.replace(file.cwd, '')] = hash;
 
                 return this;
             },
-            compare: function(file, cb){
+            compare: function(file, cb) {
 
                 var md5 = this.calc(file),
                     filepath = file.path.replace(file.cwd, ''),
@@ -321,7 +321,7 @@ function TinyPNG(opt, obj){
 
                 return cb ? this : {match: result, hash: md5};
             },
-            populate: function(){
+            populate: function() {
                 var data = false;
 
                 if(this.sigFile){
@@ -337,7 +337,7 @@ function TinyPNG(opt, obj){
 
                 return this;
             },
-            write: function(){
+            write: function() {
                 if(this.changed){
                     try{
                         fs.writeFileSync(this.sigFile, JSON.stringify(this.sigs));
@@ -352,13 +352,13 @@ function TinyPNG(opt, obj){
     };
 
     this.utils = {
-        log: function(message, force){
+        log: function(message, force) {
             if(self.conf.options.log || force) gutil.log(PLUGIN_NAME, message);
 
             return this;
         },
 
-        glob: function(file, glob, opt){
+        glob: function(file, glob, opt) {
             opt = opt || {};
             var result = false;
 
@@ -366,7 +366,8 @@ function TinyPNG(opt, obj){
 
             try{
                 result = minimatch(file.path, glob, opt);
-            } catch(err) {}
+            } catch(err){
+            }
 
             if(!result && !opt.matchBase){
                 opt.matchBase = true;
@@ -375,7 +376,7 @@ function TinyPNG(opt, obj){
             return result;
         },
 
-        prettySize: function(bytes){
+        prettySize: function(bytes) {
             if(bytes === 0) return '0.00 B';
 
             var pos = Math.floor(Math.log(bytes) / Math.log(1024));

--- a/index.js
+++ b/index.js
@@ -35,8 +35,8 @@ function TinyPNG(opt, obj) {
             parallelMax: 5,
             keepOriginal: true,
             keepMetadata: false,
-            retry_attempts: 10,
-            retry_delay: 10000
+            retryAttempts: 10,
+            retryDelay: 10000
         }
     };
 
@@ -194,8 +194,8 @@ function TinyPNG(opt, obj) {
                     },
                     strictSSL: false,
                     body: file.contents,
-                    maxAttempts: self.conf.retry_attempts,
-                    retryDelay: self.conf.retry_delay,
+                    maxAttempts: self.conf.retryAttempts,
+                    retryDelay: self.conf.retryDelay,
                     retryStrategy: request.RetryStrategies.HTTPOrNetworkError // (default) retry on 5xx or network errors
                 }, function (err, res, body) {
                     var data,

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var PLUGIN_NAME = 'gulp-tinypng-extended',
  * TinyPNG class
  * @todo Move into own library
  */
-function TinyPNG(opt, obj) {
+function TinyPNG(opt, obj){
 
     var self = this;
 
@@ -51,7 +51,7 @@ function TinyPNG(opt, obj) {
         retried: []
     };
 
-    this.init = function(opt) {
+    this.init = function(opt){
         if(typeof opt !== 'object') opt = {key: opt};
 
         opt = util._extend(this.conf.options, opt);
@@ -70,31 +70,31 @@ function TinyPNG(opt, obj) {
         return this;
     };
 
-    this.stream = function() {
+    this.stream = function(){
         var self = this,
             opt = this.conf.options;
 
-        return (opt.parallel ? throughParallel : through).obj({maxConcurrency: opt.parallelMax}, function(file, enc, cb) {
+        return (opt.parallel ? throughParallel : through).obj({maxConcurrency: opt.parallelMax}, function(file, enc, cb){
             if(self.utils.glob(file, opt.ignore)) return cb();
 
-            if(file.isNull()) {
+            if(file.isNull()){
                 return cb();
             }
 
-            if(file.isStream()) {
+            if(file.isStream()){
                 this.emit('error', new PluginError(PLUGIN_NAME, 'Streams not supported'));
                 return cb();
             }
 
-            if(file.isBuffer()) {
+            if(file.isBuffer()){
                 var hash = null;
 
-                if(opt.sigFile && !self.utils.glob(file, opt.force)) {
+                if(opt.sigFile && !self.utils.glob(file, opt.force)){
                     var result = self.hash.compare(file);
 
                     hash = result.hash;
 
-                    if(result.match) {
+                    if(result.match){
                         self.utils.log('[skipping] ' + chalk.green('✔ ') + file.relative);
                         self.stats.skipped++;
 
@@ -102,8 +102,8 @@ function TinyPNG(opt, obj) {
                     }
                 }
 
-                self.request(file).get(function(err, tinyFile) {
-                    if(err) {
+                self.request(file).get(function(err, tinyFile){
+                    if(err){
                         this.emit('error', new PluginError(PLUGIN_NAME, err));
                         return cb();
                     }
@@ -114,22 +114,22 @@ function TinyPNG(opt, obj) {
                     self.stats.total.in += file.contents.toString().length;
                     self.stats.total.out += tinyFile.contents.toString().length;
 
-                    if(opt.sigFile) {
+                    if(opt.sigFile){
                         var curr = {
                             file: file,
                             hash: hash
                         };
 
-                        if(opt.sameDest) {
+                        if(opt.sameDest){
                             curr.file = tinyFile;
                             curr.hash = self.hash.calc(tinyFile);
                         }
 
                         self.hash.update(curr.file, curr.hash);
                     }
-                    if(opt.keepOriginal === false) {
+                    if(opt.keepOriginal === false){
                         fs.writeFile(file.path, tinyFile.contents);
-                    } else {
+                    } else{
                         this.push(tinyFile);
                     }
 
@@ -137,17 +137,17 @@ function TinyPNG(opt, obj) {
                 }.bind(this)); // maintain stream context
             }
         })
-            .on('error', function(err) {
+            .on('error', function(err){
                 console.log(err.message);
                 self.stats.skipped++;
                 self.utils.log(err.message);
             })
-            .on('end', function() {
-                if(opt.sigFile) {
+            .on('end', function(){
+                if(opt.sigFile){
                     // write sigs after complete or but also when error occured in order to keep track of already compressed files
                     self.hash.write();
                 }
-                if(opt.summarize) {
+                if(opt.summarize){
                     var stats = self.stats,
                         info = util.format('Skipped: %s image%s, Retries: %s, Compressed: %s image%s, Savings: %s (ratio: %s)',
                             stats.skipped,
@@ -161,9 +161,9 @@ function TinyPNG(opt, obj) {
 
                     self.utils.log(info, true);
 
-                    if(stats.retries > 0) {
+                    if(stats.retries > 0){
                         self.utils.log('Retry Attempts:', true);
-                        stats.retried.forEach(function(item) {
+                        stats.retried.forEach(function(item){
                             self.utils.log(item.file + ': ' + item.attempts + ' attempts', true);
                         });
                     }
@@ -171,17 +171,17 @@ function TinyPNG(opt, obj) {
             });
     };
 
-    this.request = function(file, cb) {
+    this.request = function(file, cb){
         var self = this;
 
         return {
             file: file,
 
-            upload: function(cb) {
+            upload: function(cb){
                 var file = this.file;
 
                 //do not process empty files
-                if(file.contents <= 0) {
+                if(file.contents <= 0){
                     err = new Error('Error: Empty or broken images could not be send ' + file.relative);
                     return cb(err);
                 }
@@ -197,14 +197,14 @@ function TinyPNG(opt, obj) {
                     maxAttempts: self.conf.retryAttempts,
                     retryDelay: self.conf.retryDelay,
                     retryStrategy: request.RetryStrategies.HTTPOrNetworkError // (default) retry on 5xx or network errors
-                }, function(err, res, body) {
+                }, function(err, res, body){
                     var data,
                         info = {
                             url: false,
                             count: (res && 'headers' in res && res.headers['compression-count']) || 0
                         };
 
-                    if(res.attempts > 1) {
+                    if(res.attempts > 1){
                         self.stats.retries += res.attempts - 1;
                         self.stats.retried.push({
                             file: file.relative,
@@ -212,29 +212,29 @@ function TinyPNG(opt, obj) {
                         });
                     }
 
-                    if(err) {
+                    if(err){
                         err = new Error('Upload failed for ' + file.relative + ' with error: ' + err.message);
-                    } else if(body) {
-                        if(res.statusCode == 200 || res.statusCode == 201) {
-                            try {
+                    } else if(body){
+                        if(res.statusCode == 200 || res.statusCode == 201){
+                            try{
                                 data = JSON.parse(body);
-                            } catch(e) {
+                            } catch(e){
                                 err = new Error('Upload response JSON parse failed, invalid data returned from API. Failed with message: ' + e.message);
                             }
 
-                            if(!err) {
-                                if(data.error) {
+                            if(!err){
+                                if(data.error){
                                     err = this.handler(data, res.statusCode);
-                                } else if(data.output.url) {
+                                } else if(data.output.url){
                                     info.url = self.conf.options.keepMetadata ? res.headers.location : data.output.url;
-                                } else {
+                                } else{
                                     err = new Error('Invalid TinyPNG response object returned for ' + file.relative);
                                 }
                             }
-                        } else {
+                        } else{
                             err = new Error('Error: Statuscode ' + res.statusCode + ' returned');
                         }
-                    } else {
+                    } else{
                         err = new Error('No content returned from TinyPNG API for' + file.relative);
                     }
 
@@ -242,24 +242,24 @@ function TinyPNG(opt, obj) {
                 }.bind(this));
             },
 
-            download: function(url, cb) {
+            download: function(url, cb){
                 var options = {
                     url: url,
                     encoding: null
                 };
 
-                if(self.conf.options.keepMetadata) {
+                if(self.conf.options.keepMetadata){
                     options.json = {preserve: ["copyright", "creation"]};
                     options.headers = {
                         'Authorization': 'Basic ' + self.conf.token
                     };
                 }
-                request.get(options, function(err, res, body) {
+                request.get(options, function(err, res, body){
                     err = err ? new Error('Download failed for ' + url + ' with error: ' + err.message) : false;
                     var buffer = false;
-                    try {
+                    try{
                         buffer = new Buffer(body);
-                    } catch(err) {
+                    } catch(err){
                         return cb(new Error('Empty Body for Download with error: ' + err.message));
                     }
 
@@ -267,18 +267,18 @@ function TinyPNG(opt, obj) {
                 });
             },
 
-            handler: function(data, status) {
+            handler: function(data, status){
                 return new Error((data.error || 'Unknown') + ' (' + status + '): ' + (data.message || 'No message returned') + ' for ' + file.relative);
             },
 
-            get: function(cb) {
+            get: function(cb){
                 var self = this,
                     file = this.file;
 
-                self.upload(function(err, data) {
+                self.upload(function(err, data){
                     if(err) return cb(err, file);
 
-                    self.download(data.url, function(err, data) {
+                    self.download(data.url, function(err, data){
                         if(err) return cb(err, file);
 
                         var tinyFile = file.clone();
@@ -293,25 +293,25 @@ function TinyPNG(opt, obj) {
         };
     };
 
-    this.hasher = function(sigFile) {
+    this.hasher = function(sigFile){
         return {
             sigFile: sigFile || false,
             sigs: {},
 
-            calc: function(file, cb) {
+            calc: function(file, cb){
                 var md5 = crypto.createHash('md5').update(file.contents).digest('hex');
 
                 cb && cb(md5);
 
                 return cb ? this : md5;
             },
-            update: function(file, hash) {
+            update: function(file, hash){
                 this.changed = true;
                 this.sigs[file.path.replace(file.cwd, '')] = hash;
 
                 return this;
             },
-            compare: function(file, cb) {
+            compare: function(file, cb){
 
                 var md5 = this.calc(file),
                     filepath = file.path.replace(file.cwd, ''),
@@ -321,14 +321,14 @@ function TinyPNG(opt, obj) {
 
                 return cb ? this : {match: result, hash: md5};
             },
-            populate: function() {
+            populate: function(){
                 var data = false;
 
-                if(this.sigFile) {
-                    try {
+                if(this.sigFile){
+                    try{
                         data = fs.readFileSync(this.sigFile, 'utf-8');
                         if(data) data = JSON.parse(data);
-                    } catch(err) {
+                    } catch(err){
                         // meh
                     }
 
@@ -337,11 +337,11 @@ function TinyPNG(opt, obj) {
 
                 return this;
             },
-            write: function() {
-                if(this.changed) {
-                    try {
+            write: function(){
+                if(this.changed){
+                    try{
                         fs.writeFileSync(this.sigFile, JSON.stringify(this.sigs));
-                    } catch(err) {
+                    } catch(err){
                         // meh
                     }
                 }
@@ -352,31 +352,30 @@ function TinyPNG(opt, obj) {
     };
 
     this.utils = {
-        log: function(message, force) {
+        log: function(message, force){
             if(self.conf.options.log || force) gutil.log(PLUGIN_NAME, message);
 
             return this;
         },
 
-        glob: function(file, glob, opt) {
+        glob: function(file, glob, opt){
             opt = opt || {};
             var result = false;
 
             if(typeof glob === 'boolean') return glob;
 
-            try {
+            try{
                 result = minimatch(file.path, glob, opt);
-            } catch(err) {
-            }
+            } catch(err) {}
 
-            if(!result && !opt.matchBase) {
+            if(!result && !opt.matchBase){
                 opt.matchBase = true;
                 return this.glob(file, glob, opt);
             }
             return result;
         },
 
-        prettySize: function(bytes) {
+        prettySize: function(bytes){
             if(bytes === 0) return '0.00 B';
 
             var pos = Math.floor(Math.log(bytes) / Math.log(1024));

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function TinyPNG(opt, obj) {
         return (opt.parallel ? throughParallel : through).obj({maxConcurrency: opt.parallelMax}, function(file, enc, cb) {
             if(self.utils.glob(file, opt.ignore)) return cb();
 
-            if(file.isNull()){
+            if(file.isNull()) {
                 return cb();
             }
 
@@ -86,15 +86,15 @@ function TinyPNG(opt, obj) {
                 return cb();
             }
 
-            if(file.isBuffer()){
+            if(file.isBuffer()) {
                 var hash = null;
 
-                if(opt.sigFile && !self.utils.glob(file, opt.force)){
+                if(opt.sigFile && !self.utils.glob(file, opt.force)) {
                     var result = self.hash.compare(file);
 
                     hash = result.hash;
 
-                    if(result.match){
+                    if(result.match) {
                         self.utils.log('[skipping] ' + chalk.green('✔ ') + file.relative);
                         self.stats.skipped++;
 
@@ -103,7 +103,7 @@ function TinyPNG(opt, obj) {
                 }
 
                 self.request(file).get(function(err, tinyFile) {
-                    if(err){
+                    if(err) {
                         this.emit('error', new PluginError(PLUGIN_NAME, err));
                         return cb();
                     }
@@ -114,22 +114,22 @@ function TinyPNG(opt, obj) {
                     self.stats.total.in += file.contents.toString().length;
                     self.stats.total.out += tinyFile.contents.toString().length;
 
-                    if(opt.sigFile){
+                    if(opt.sigFile) {
                         var curr = {
                             file: file,
                             hash: hash
                         };
 
-                        if(opt.sameDest){
+                        if(opt.sameDest) {
                             curr.file = tinyFile;
                             curr.hash = self.hash.calc(tinyFile);
                         }
 
                         self.hash.update(curr.file, curr.hash);
                     }
-                    if(opt.keepOriginal === false){
+                    if(opt.keepOriginal === false) {
                         fs.writeFile(file.path, tinyFile.contents);
-                    } else{
+                    } else {
                         this.push(tinyFile);
                     }
 
@@ -137,38 +137,38 @@ function TinyPNG(opt, obj) {
                 }.bind(this)); // maintain stream context
             }
         })
-            .on('error', function(err) {
-                console.log(err.message);
-                self.stats.skipped++;
-                self.utils.log(err.message);
-            })
-            .on('end', function() {
-                if(opt.sigFile){
-                    // write sigs after complete or but also when error occured in order to keep track of already compressed files
-                    self.hash.write();
-                }
-                if(opt.summarize){
-                    var stats = self.stats,
-                        info = util.format('Skipped: %s image%s, Retries: %s, Compressed: %s image%s, Savings: %s (ratio: %s)',
-                            stats.skipped,
-                            stats.skipped == 1 ? '' : 's',
-                            stats.retries,
-                            stats.compressed,
-                            stats.compressed == 1 ? '' : 's',
-                            (self.utils.prettySize(stats.total.in - stats.total.out)),
-                            (stats.total.in ? Math.round(stats.total.out / stats.total.in * 10000) / 10000 : 0)
-                        );
+        .on('error', function(err) {
+            console.log(err.message);
+            self.stats.skipped++;
+            self.utils.log(err.message);
+        })
+        .on('end', function() {
+            if(opt.sigFile) {
+                // write sigs after complete or but also when error occured in order to keep track of already compressed files
+                self.hash.write();
+            }
+            if(opt.summarize) {
+                var stats = self.stats,
+                    info = util.format('Skipped: %s image%s, Retries: %s, Compressed: %s image%s, Savings: %s (ratio: %s)',
+                        stats.skipped,
+                        stats.skipped == 1 ? '' : 's',
+                        stats.retries,
+                        stats.compressed,
+                        stats.compressed == 1 ? '' : 's',
+                        (self.utils.prettySize(stats.total.in - stats.total.out)),
+                        (stats.total.in ? Math.round(stats.total.out / stats.total.in * 10000) / 10000 : 0)
+                    );
 
-                    self.utils.log(info, true);
+                self.utils.log(info, true);
 
-                    if(stats.retries > 0){
-                        self.utils.log('Retry Attempts:', true);
-                        stats.retried.forEach(function(item) {
-                            self.utils.log(item.file + ': ' + item.attempts + ' attempts', true);
-                        });
-                    }
+                if(stats.retries > 0) {
+                    self.utils.log('Retry Attempts:', true);
+                    stats.retried.forEach(function(item) {
+                        self.utils.log(item.file + ': ' + item.attempts + ' attempts', true);
+                    });
                 }
-            });
+            }
+        });
     };
 
     this.request = function(file, cb) {
@@ -181,7 +181,7 @@ function TinyPNG(opt, obj) {
                 var file = this.file;
 
                 //do not process empty files
-                if(file.contents <= 0){
+                if(file.contents <= 0) {
                     err = new Error('Error: Empty or broken images could not be send ' + file.relative);
                     return cb(err);
                 }
@@ -212,29 +212,29 @@ function TinyPNG(opt, obj) {
                         });
                     }
 
-                    if(err){
+                    if(err) {
                         err = new Error('Upload failed for ' + file.relative + ' with error: ' + err.message);
-                    } else if(body){
+                    } else if(body) {
                         if(res.statusCode == 200 || res.statusCode == 201){
-                            try{
+                            try {
                                 data = JSON.parse(body);
-                            } catch(e){
+                            } catch(e) {
                                 err = new Error('Upload response JSON parse failed, invalid data returned from API. Failed with message: ' + e.message);
                             }
 
-                            if(!err){
+                            if(!err) {
                                 if(data.error){
                                     err = this.handler(data, res.statusCode);
-                                } else if(data.output.url){
+                                } else if (data.output.url){
                                     info.url = self.conf.options.keepMetadata ? res.headers.location : data.output.url;
-                                } else{
+                                } else {
                                     err = new Error('Invalid TinyPNG response object returned for ' + file.relative);
                                 }
                             }
-                        } else{
+                        } else {
                             err = new Error('Error: Statuscode ' + res.statusCode + ' returned');
                         }
-                    } else{
+                    } else {
                         err = new Error('No content returned from TinyPNG API for' + file.relative);
                     }
 
@@ -248,8 +248,8 @@ function TinyPNG(opt, obj) {
                     encoding: null
                 };
 
-                if(self.conf.options.keepMetadata){
-                    options.json = {preserve: ["copyright", "creation"]};
+                if(self.conf.options.keepMetadata) {
+                    options.json = { preserve: ["copyright", "creation"] };
                     options.headers = {
                         'Authorization': 'Basic ' + self.conf.token
                     };
@@ -319,13 +319,13 @@ function TinyPNG(opt, obj) {
 
                 cb && cb(result, md5);
 
-                return cb ? this : {match: result, hash: md5};
+                return cb ? this : { match: result, hash: md5 };
             },
             populate: function() {
                 var data = false;
 
-                if(this.sigFile){
-                    try{
+                if(this.sigFile) {
+                    try {
                         data = fs.readFileSync(this.sigFile, 'utf-8');
                         if(data) data = JSON.parse(data);
                     } catch(err){
@@ -338,10 +338,10 @@ function TinyPNG(opt, obj) {
                 return this;
             },
             write: function() {
-                if(this.changed){
-                    try{
+                if(this.changed) {
+                    try {
                         fs.writeFileSync(this.sigFile, JSON.stringify(this.sigs));
-                    } catch(err){
+                    } catch(err) {
                         // meh
                     }
                 }
@@ -364,12 +364,12 @@ function TinyPNG(opt, obj) {
 
             if(typeof glob === 'boolean') return glob;
 
-            try{
+            try {
                 result = minimatch(file.path, glob, opt);
-            } catch(err){
+            } catch(err) {
             }
 
-            if(!result && !opt.matchBase){
+            if(!result && !opt.matchBase) {
                 opt.matchBase = true;
                 return this.glob(file, glob, opt);
             }

--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ function TinyPNG(opt, obj) {
             out: 0
         },
         compressed: 0,
-        skipped: 0
+        skipped: 0,
+        retries: 0
     };
 
     this.init = function(opt) {
@@ -145,9 +146,10 @@ function TinyPNG(opt, obj) {
             }
             if(opt.summarize) {
                 var stats = self.stats,
-                    info = util.format('Skipped: %s image%s, Compressed: %s image%s, Savings: %s (ratio: %s)',
+                    info = util.format('Skipped: %s image%s, Retries: %s, Compressed: %s image%s, Savings: %s (ratio: %s)',
                         stats.skipped,
                         stats.skipped == 1 ? '' : 's',
+                        stats.retries,
                         stats.compressed,
                         stats.compressed == 1 ? '' : 's',
                         (self.utils.prettySize(stats.total.in - stats.total.out)),
@@ -191,6 +193,9 @@ function TinyPNG(opt, obj) {
                             url: false,
                             count: (res && 'headers' in res && res.headers['compression-count']) || 0
                         };
+
+                    self.stats.retries += res.attempts;
+
                     if(err) {
                         err = new Error('Upload failed for ' + file.relative + ' with error: ' + err.message);
                     } else if(body) {

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function TinyPNG(opt, obj) {
                 return cb();
             }
 
-            if(file.isStream()){
+            if(file.isStream()) {
                 this.emit('error', new PluginError(PLUGIN_NAME, 'Streams not supported'));
                 return cb();
             }
@@ -127,7 +127,7 @@ function TinyPNG(opt, obj) {
 
                         self.hash.update(curr.file, curr.hash);
                     }
-                    if(opt.keepOriginal === false) {
+                    if (opt.keepOriginal === false) {
                         fs.writeFile(file.path, tinyFile.contents);
                     } else {
                         this.push(tinyFile);
@@ -215,7 +215,7 @@ function TinyPNG(opt, obj) {
                     if(err) {
                         err = new Error('Upload failed for ' + file.relative + ' with error: ' + err.message);
                     } else if(body) {
-                        if(res.statusCode == 200 || res.statusCode == 201){
+                        if(res.statusCode == 200 || res.statusCode == 201) {
                             try {
                                 data = JSON.parse(body);
                             } catch(e) {
@@ -225,7 +225,7 @@ function TinyPNG(opt, obj) {
                             if(!err) {
                                 if(data.error){
                                     err = this.handler(data, res.statusCode);
-                                } else if (data.output.url){
+                                } else if (data.output.url) {
                                     info.url = self.conf.options.keepMetadata ? res.headers.location : data.output.url;
                                 } else {
                                     err = new Error('Invalid TinyPNG response object returned for ' + file.relative);
@@ -248,7 +248,7 @@ function TinyPNG(opt, obj) {
                     encoding: null
                 };
 
-                if(self.conf.options.keepMetadata) {
+                if (self.conf.options.keepMetadata) {
                     options.json = { preserve: ["copyright", "creation"] };
                     options.headers = {
                         'Authorization': 'Basic ' + self.conf.token
@@ -257,9 +257,9 @@ function TinyPNG(opt, obj) {
                 request.get(options, function(err, res, body) {
                     err = err ? new Error('Download failed for ' + url + ' with error: ' + err.message) : false;
                     var buffer = false;
-                    try{
+                     try {
                         buffer = new Buffer(body);
-                    } catch(err){
+                    } catch(err) {
                         return cb(new Error('Empty Body for Download with error: ' + err.message));
                     }
 
@@ -328,7 +328,7 @@ function TinyPNG(opt, obj) {
                     try {
                         data = fs.readFileSync(this.sigFile, 'utf-8');
                         if(data) data = JSON.parse(data);
-                    } catch(err){
+                    } catch(err) {
                         // meh
                     }
 
@@ -366,8 +366,7 @@ function TinyPNG(opt, obj) {
 
             try {
                 result = minimatch(file.path, glob, opt);
-            } catch(err) {
-            }
+            } catch(err) {}
 
             if(!result && !opt.matchBase) {
                 opt.matchBase = true;

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "gulp-util": "~3.0.0",
     "minimatch": "^3.0.0",
     "request": "~2.55.0",
+    "requestretry": "^1.12.0",
     "through2": "^2.0.0",
     "through2-concurrent": "^1.1.0"
   },

--- a/test/init.js
+++ b/test/init.js
@@ -11,7 +11,7 @@ var fs = require('fs'),
 
     TinyPNG = require('../index');
 
-var key = 'KHOsJMrP6w-X3FVuyXdevV-vCnDDbqo9',
+var key = '9C2FqRbMQwDFtKyNSeJlu-VMP4-oEXH4',
 	cwd = __dirname,
 	TestFile = function(type) {
 		var file = cwd + '/assets/image' + (type ? '_' + type : '') + '.png';
@@ -88,7 +88,7 @@ describe('tinypng', function() {
 				});
 			});
 
-			it('uploads and returns bad gateway error', function(done) {
+			it('uploads and and tries to retry on bad gateway error', function(done) {
 				this.timeout(20010);
 
 				var gateway = nock('https://api.tinify.com')
@@ -97,7 +97,6 @@ describe('tinypng', function() {
 
 				inst.request(image).upload(function(err, data) {
 					expect(err).to.be.instanceof(Error);
-					expect(err.message).to.equal('Error: Statuscode 502 returned');
 					nock.cleanAll();
 					done();
 				});
@@ -330,7 +329,7 @@ describe('tinypng gulp', function() {
 	});
 
 	it('ignores files on the cli', function(done) {
-		this.timeout(20000);
+		this.timeout(30000);
 
 		var sh = spawn('node', ['node_modules/gulp/bin/gulp.js', 'tinypng', '--ignore', '*ge.png']);
 


### PR DESCRIPTION
Here is a pull request that I hope satisfies Issue #11:

- added new dependency: [requestretry](https://github.com/FGRibreau/node-request-retry)
- added config options to change requestAttempts and requestDelay
- added _Retries: 0_ to summary output log
- added list of files along with the number of upload attempts to summary output log
- updated README.md with new config options