### PR TITLE
Make writeFile call synchronous when keepOriginal === false

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ function TinyPNG(opt, obj) {
                         self.hash.update(curr.file, curr.hash);
                     }
                     if (opt.keepOriginal === false) {
-                        fs.writeFile(file.path, tinyFile.contents);
+                        fs.writeFileSync(file.path, tinyFile.contents);
                     } else {
                         this.push(tinyFile);
                     }


### PR DESCRIPTION
Fixes bug when keepOriginal option is false.

`writeFile` expects a 3rd callback parameter and throws `ERR_INVALID_CALLBACK: Callback must be a function` if not provided.